### PR TITLE
Make jsDoc information available for template rendering.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc -p src",
-    "test": "npm run build && node dist/ts2lang-main --file test/ts2lang.json",
+    "test": "npm run build && copy package.json dist && node dist/ts2lang-main --file test/ts2lang.json",
     "go": "npm run build && node dist/ts2lang-main",
     "pack": "npm run build && copy package.json dist && cd dist && del /Q *.tgz && npm pack && copy *.tgz .. && cd .."
   },
@@ -20,7 +20,6 @@
     "commander": "^2.9.0",
     "glob": "^7.1.2",
     "is-directory": "^0.3.1",
-    "merge": "^1.2.0",
     "typescript": "^4.1.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outsystems/ts2lang",
-  "version": "1.0.16",
+  "version": "1.1.0",
   "description": "TypeScript to (language) bindings generator",
   "main": "ts2lang.js",
   "bin": {

--- a/src/template-runner.ts
+++ b/src/template-runner.ts
@@ -13,6 +13,13 @@ function getFunctionReturnType(func: Units.TsFunction): string {
 class DummyTemplate {
     
     constructor(private context: Object) {}
+
+    dumpDoc = (u: Units.INamedTsUnit) => {
+        if (u.documentation) {
+            return `DOCS[${JSON.stringify(u.documentation)}]\n`;
+        }
+        return "";
+    }
     
     dumpModule = (module: Units.TsModule) => {
         return module.classes.map(this.dumpClass).join("\n") + "\n" + 
@@ -21,25 +28,28 @@ class DummyTemplate {
     }
     
     dumpClass = (klass: Units.TsClass) => {
-        return `CLASS ${klass.name}${this.context["extraInfo1"]} {\n` +
+        return this.dumpDoc(klass) +
+            `CLASS ${klass.name}${this.context["extraInfo1"]} {\n` +
             klass.functions.map(this.dumpMethod).join("\n") +
             "\n}";
     }
 
     dumpInterface = (interf: Units.TsInterface) => {
-        return `INTERFACE ${interf.name}${this.context["extraInfo1"]} {\n` +
+        return this.dumpDoc(interf) +
+            `INTERFACE ${interf.name}${this.context["extraInfo1"]} {\n` +
             interf.functions.map(this.dumpMethod).join("\n") +
             "\n}";
     }
     
     dumpMethod = (method: Units.TsFunction) => {
-        let parameters = method.parameters.map(p => `${p.name}: ${p.type.name}`).join(", ");
-        return `${getFunctionReturnType(method)} ${method.name}(${parameters})`;
+        let parameters = method.parameters.map(p => `${this.dumpDoc(p)}${p.name}: ${p.type.name}`).join(", ");
+        return this.dumpDoc(method) + `${getFunctionReturnType(method)} ${method.name}(${parameters})`;
     }
 
     dumpEnum = (enumz: Units.TsEnum) => {
-        return `ENUM ${enumz.name} {\n` +
-            enumz.options.map(x => { return x.name + (x.id === undefined? "" : " = " + x.id) }).join(",\n") +
+        return this.dumpDoc(enumz) +
+            `ENUM ${enumz.name} {\n` +
+            enumz.options.map(x => { return this.dumpDoc(x) + x.name + (x.id === undefined? "" : " = " + x.id) }).join(",\n") +
             "\n}";
     }
 }

--- a/src/ts-units.ts
+++ b/src/ts-units.ts
@@ -10,6 +10,12 @@ export interface ITsAnnotation {
     args: ITsAnnotationArgument[];
 }
 
+/** a code unit that has a name and possibly a jsdoc comment */
+export interface INamedTsUnit {
+    name: string;
+    documentation: string;
+}
+
 export interface ITsUnit {
     annotations: ITsAnnotation[];
 
@@ -36,9 +42,11 @@ export interface ITopLevelTsUnit extends ITsUnit {
 export abstract class AbstractTsUnit implements ITsUnit {
     name: string;
     annotations: ITsAnnotation[] = [];
+    documentation: string;
 
-    constructor(name: string) {
+    constructor(name: string, documentation: string) {
         this.name = name;
+        this.documentation = documentation;
     }
 
     addAnnotation(annot: ITsAnnotation): void {
@@ -61,8 +69,8 @@ export abstract class TopLevelTsUnit extends AbstractTsUnit implements ITopLevel
     enums: TsEnum[] = [];
     isPublic: boolean;
 
-    constructor(name: string, isPublic = false) {
-        super(name);
+    constructor(name: string, isPublic = false, documentation = null) {
+        super(name, documentation);
         this.isPublic = isPublic;
     }
 
@@ -90,10 +98,12 @@ export abstract class TopLevelTsUnit extends AbstractTsUnit implements ITopLevel
 export class TsParameter {
     name: string;
     type: ITsType;
+    documentation: string;
 
-    constructor(name: string, type: ITsType) {
+    constructor(name: string, type: ITsType, documentation: string = null) {
         this.name = name;
         this.type = type;
+        this.documentation = documentation;
     }
 }
 
@@ -102,8 +112,8 @@ export class TsFunction extends AbstractTsUnit {
     parameters: TsParameter[];
     returnType: ITsType;
 
-    constructor(name: string, parameters: TsParameter[], returnType: ITsType) {
-        super(name);
+    constructor(name: string, parameters: TsParameter[], returnType: ITsType, documentation: string = null) {
+        super(name, documentation);
         this.parameters = parameters;
         this.returnType = returnType;
     }
@@ -114,8 +124,8 @@ export class TsEnum extends AbstractTsUnit {
     options: TsEnumOption[];
     isPublic: boolean;
 
-    constructor(name: string, options: TsEnumOption[], isPublic = false) {
-        super(name);
+    constructor(name: string, options: TsEnumOption[], isPublic = false, documentation: string = null) {
+        super(name, documentation);
         this.name = name;
         this.options = options;
         this.isPublic = isPublic;
@@ -125,10 +135,12 @@ export class TsEnum extends AbstractTsUnit {
 export class TsEnumOption {
     name: string;
     id: number;
+    documentation: string;
 
-    constructor(name: string, id: number) {
+    constructor(name: string, id: number, documentation: string) {
         this.name = name;
         this.id = id;
+        this.documentation = documentation;
     }
 }
 
@@ -159,10 +171,12 @@ export class TsProperty {
     name: string;
     type: ITsType;
     isReadOnly: boolean;
+    documentation: string;
 
-    constructor(name: string, type: ITsType, isReadOnly: boolean) {
+    constructor(name: string, type: ITsType, isReadOnly: boolean, documentation: string) {
         this.name = name;
         this.type = type;
         this.isReadOnly = isReadOnly;
+        this.documentation = documentation;
     }
 }

--- a/src/ts2lang.ts
+++ b/src/ts2lang.ts
@@ -1,11 +1,8 @@
-/// <reference path="merge.d.ts" />
-
 import * as ts from "typescript";
 import * as analyser from "./ts-analyser";
 import * as Templates from "./template-runner";
 import { read as readConfiguration, getTaskParameters, IConfigurationTask } from "./configuration";
 import { resolve as pathCombine, dirname, normalize, sep as pathSeparator } from "path";
-import * as merge from "merge";
 import { writeFileSync, existsSync, mkdirSync } from "fs";
 import { sync as isDirectory } from "is-directory";
 import * as glob from "glob";
@@ -78,14 +75,14 @@ export function runProject(filePath: string, fileDir: string, defaultTemplate: s
             let taskParameters = getTaskParameters(task);
             let template = task.template || defaultTemplate;
 
-            let context: any =
-                merge({
-                    $fullpath: file.fileName,
-                    $path: task.input,
-                    $output: task.output,
-                    $template: template,
-                    $baseDir: fileDir
-                }, taskParameters);
+            let context: any = {
+                ...taskParameters,
+                $fullpath: file.fileName,
+                $path: task.input,
+                $output: task.output,
+                $template: template,
+                $baseDir: fileDir
+            };
 
             try {
                 let moduleInfo = analyser.collectInformation(program, file, file.fileName);

--- a/test/source-feed.ts
+++ b/test/source-feed.ts
@@ -1,20 +1,27 @@
 import { IBasePoint } from "./source-dependency";
 
+/** doc on interface */
 export interface IPoint extends IBasePoint {
     distanceFromOrigin(): number;
     distance(other: Point): number;
 }
 
+/**
+ * doc on class
+ * on multiple lines
+ */
 class Point implements IPoint {
     readonly name: string;
     x: number;
     y: number;
     
+    /** doc on prop */
     getX(): number { return this.x; }
     getY(): number { return this.y; }
 
+    /** doc on method */
     /*@ts2lang convertToType(X=a | a=b)*/
-    public distance(other: Point): number {
+    public distance(/** doc on param */ other: Point): number {
         return Math.sqrt((this.x - other.x) ** 2 + (this.y - other.y) ** 2);
     }
     
@@ -26,11 +33,13 @@ class Point implements IPoint {
     }
 }
 
+/** doc on enum */
 enum MyEnum { 
     // cenas
     A = 1,
     /* TEST */
     B,//67
     C = 99 /* xxx 45 */,
+    /** doc on enum value */
     D = 2 // 33
 }


### PR DESCRIPTION
This PR makes a few changes so that jsDoc information is collected into the TsUnits and therefore available for template rendering. This means that in a case where we're creating C# bindings from TS signatures, we can change the template code to generate `<summary>` xmldocs based on the original jsdocs and have inline documentation everywhere.

Since this is a new property, I've bumped the minor version of the package.

I also removed the dependency to the `merge` package because it wasn't really necessary and because the version of `merge` that was referenced had assigned vulnerability reports.